### PR TITLE
Increase accuracy to reading the board address (board-ID)

### DIFF
--- a/src/IOBoardController.cpp
+++ b/src/IOBoardController.cpp
@@ -11,9 +11,8 @@ IOBoardController::IOBoardController(int cT)
 
     if (controllerType == CONTROLLER_16_8_1)
     {
-        // Read bordID. The read value is between 60 and 940.
-        boardId = 16 - ((int)((analogRead(28) + 30) / 60));
-
+        // Read bordID. Ideal value at 10bit resolution: (DIP+1)*1023*2/35 -> 58.46 to 935.3
+        boardId = 16 - ((int)((analogRead(28) + 29.32) / 58.46));
         _eventDispatcher->setRS485ModePin(2);
         _eventDispatcher->setBoard(boardId);
         _eventDispatcher->setCrossLinkSerial(Serial1);

--- a/src/IOBoardController.cpp
+++ b/src/IOBoardController.cpp
@@ -12,7 +12,7 @@ IOBoardController::IOBoardController(int cT)
     if (controllerType == CONTROLLER_16_8_1)
     {
         // Read bordID. Ideal value at 10bit resolution: (DIP+1)*1023*2/35 -> 58.46 to 935.3
-        boardId = 16 - ((int)((analogRead(28) + 29.32) / 58.46));
+        boardId = 16 - ((int)((analogRead(28) + 29.23) / 58.46));
         _eventDispatcher->setRS485ModePin(2);
         _eventDispatcher->setBoard(boardId);
         _eventDispatcher->setCrossLinkSerial(Serial1);


### PR DESCRIPTION
Higher accuracy is necessary to prevent calculating a wrong board-ID if part tolerances add up to calculation inaccuracy. 